### PR TITLE
Handle dynamic forms

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -33,6 +33,42 @@ class Data extends AbstractHelper /** * @var EncryptorInterface */
         return $apiKey;
     }
 
+    public function getCheckoutTargets($scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT)
+    {
+        $apiKey = $this->scopeConfig->getValue(
+            'idealpostcodes/settings/checkout_targets',
+            $scope
+        );
+        return $apiKey;
+    }
+
+    public function getCustomerAddressTarget($scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT)
+    {
+        $apiKey = $this->scopeConfig->getValue(
+            'idealpostcodes/settings/customer_address_target',
+            $scope
+        );
+        return $apiKey;
+    }
+
+    public function getMultishippingCheckoutTargets($scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT)
+    {
+        $apiKey = $this->scopeConfig->getValue(
+            'idealpostcodes/settings/multishipping_checkout_targets',
+            $scope
+        );
+        return $apiKey;
+    }
+
+    public function getMultishippingCheckoutRegisterTarget($scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT)
+    {
+        $apiKey = $this->scopeConfig->getValue(
+            'idealpostcodes/settings/multishipping_checkout_register_target',
+            $scope
+        );
+        return $apiKey;
+    }
+
     public function getUserToken(
         $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT
     ) {
@@ -98,7 +134,11 @@ class Data extends AbstractHelper /** * @var EncryptorInterface */
             'addressAutocomplete' => $this->usesAutocomplete($scope),
             'populateOrganisation' => $this->populateOrganisation($scope),
             'hoistCountryField' => $this->hoistCountry($scope),
-            'requireCounty' => $this->requireCounty($scope)
+            'requireCounty' => $this->requireCounty($scope),
+            'checkout_targets' => $this->getCheckoutTargets($scope),
+            'customer_address_target' => $this->getCustomerAddressTarget($scope),
+            'multishipping_checkout_targets' => $this->getMultishippingCheckoutTargets($scope),
+            'multishipping_checkout_register_target' => $this->getMultishippingCheckoutRegisterTarget($scope)
         );
         return $config;
     }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This extension enables [Ideal-Postcodes.co.uk](https://ideal-postcodes.co.uk) ad
 - **Option** hoists country selection above address fields
 - **Option** populate Company name based on address
 - **Option** populate county field
+- **Option** specify custom address forms to deploy address validation
 - [Administration Page](https://img.ideal-postcodes.co.uk/idpc-options.png)
   - Insert API Key credentials
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -159,6 +159,88 @@
         </field>
       </group>
       <group
+        id="customise"
+        translate="label"
+        sortOrder="40"
+        showInDefault="1"
+        showInWebsite="1"
+        showInStore="1"
+      >
+        <label>Advanced Configuration</label>
+        <field
+          id="checkout_targets"
+          type="text"
+          translate="label,comment"
+          sortOrder="30"
+          showInDefault="1"
+          showInWebsite="1"
+          showInStore="1"
+        >
+          <label>Checkout Targets</label>
+          <comment>
+            Customer Checkout Page. Update the target address form which the plugin should attach to. The target should be a DOM element which encompasses your address fields. Use CSS selectors, e.g. "#shipping-address,#billing-addresss"
+          </comment>
+          <config_path>idealpostcodes/settings/checkout_targets</config_path>
+          <depends>
+            <field id="enabled">1</field>
+          </depends>
+        </field>
+        <field
+          id="customer_address_target"
+          type="text"
+          translate="label,comment"
+          sortOrder="30"
+          showInDefault="1"
+          showInWebsite="1"
+          showInStore="1"
+        >
+          <label>Customer Address Edit Targets</label>
+          <comment>
+            Customer Address Edit Pages. Update the target address form which the plugin should attach to. The target should be a DOM element which encompasses your address fields. Use CSS selectors, e.g. "#shipping-address,#billing-addresss"
+          </comment>
+          <config_path>idealpostcodes/settings/customer_address_target</config_path>
+          <depends>
+            <field id="enabled">1</field>
+          </depends>
+        </field>
+        <field
+          id="multishipping_checkout_targets"
+          type="text"
+          translate="label,comment"
+          sortOrder="30"
+          showInDefault="1"
+          showInWebsite="1"
+          showInStore="1"
+        >
+          <label>Multi Shipping Checkout Targets</label>
+          <comment>
+            Multi Shipping Checkout Pages. Update the target address form which the plugin should attach to. The target should be a DOM element which encompasses your address fields. Use CSS selectors, e.g. "#shipping-address,#billing-addresss"
+          </comment>
+          <config_path>idealpostcodes/settings/multishipping_checkout_targets</config_path>
+          <depends>
+            <field id="enabled">1</field>
+          </depends>
+        </field>
+        <field
+          id="multishipping_checkout_register_target"
+          type="text"
+          translate="label,comment"
+          sortOrder="30"
+          showInDefault="1"
+          showInWebsite="1"
+          showInStore="1"
+        >
+          <label>Multi Shipping Checkout Register Target</label>
+          <comment>
+            Mutli Shipping Register Pages. Update the target address form which the plugin should attach to. The target should be a DOM element which encompasses your address fields. Use CSS selectors, e.g. "#shipping-address,#billing-addresss"
+          </comment>
+          <config_path>idealpostcodes/settings/multishipping_checkout_register_target</config_path>
+          <depends>
+            <field id="enabled">1</field>
+          </depends>
+        </field>
+      </group>
+      <group
         id="admin"
         translate="label"
         sortOrder="30"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -13,6 +13,10 @@
         <populate_organisation>1</populate_organisation>
         <require_county>0</require_county>
         <hoist_country>1</hoist_country>
+        <checkout_targets>#checkout-step-shipping form,.billing-address-form</checkout_targets>
+        <customer_address_target>#form-validate</customer_address_target>
+        <multishipping_checkout_targets>#form-validate</multishipping_checkout_targets>
+        <multishipping_checkout_register_target>#form-validate</multishipping_checkout_register_target>
       </settings>
     </idealpostcodes>
   </default>

--- a/view/frontend/templates/checkout_index_index.phtml
+++ b/view/frontend/templates/checkout_index_index.phtml
@@ -1,61 +1,37 @@
 <?php
 $helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data'); ?>
+
 <script type="text/javascript">
-(function () {
-  var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
-  var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
-  var addressAutocomplete = <?php echo $helper->getConfig(
+requirejs(['jquery'], function(jQuery){
+  jQuery(function() {
+    var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
+    var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
+    var addressAutocomplete = <?php echo $helper->getConfig(
       'addressAutocomplete'
-  ); ?>;
-  var populateOrganisation = <?php echo $helper->getConfig(
+    ); ?>;
+    var populateOrganisation = <?php echo $helper->getConfig(
       'populateOrganisation'
-  ); ?>;
-  var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
-  var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
-  var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+    ); ?>;
+    var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
+    var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
+    var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+    var targets = "<?php echo $helper->getConfig('checkout_targets'); ?>";
 
-  requirejs(['jquery'], function(jQuery){
-    jQuery(function() {
-      // Exit early if disabled
-      if (enabled === false) return;
+    // Exit early if disabled
+    if (enabled === false) return;
 
-      var shippingFormBinding  = new IdpcBinding({
-        container: '#checkout-step-shipping',
+    window.idpc = new IdpcWatcher({
+      targets: targets,
+      options: {
         api_key: api_key,
         postcodeLookup: postcodeLookup,
         requireCounty: requireCounty,
         addressAutocomplete: addressAutocomplete,
         populateOrganisation: populateOrganisation,
         hoistCountryField: hoistCountryField,
-        jQuery: jQuery
-      });
-
-      var billingFormBindings = [];
-      var interval = setInterval(function () {
-        var $instances = jQuery(".billing-address-form");
-        if ($instances.length === 0) return;
-        clearInterval(interval);
-        $instances.each(function (_, $instance) {
-          billingFormBindings.push(
-            new IdpcBinding({
-              container: $instance,
-              api_key: api_key,
-              postcodeLookup: postcodeLookup,
-              requireCounty: requireCounty,
-              addressAutocomplete: addressAutocomplete,
-              populateOrganisation: populateOrganisation,
-              hoistCountryField: hoistCountryField,
-              jQuery: jQuery
-            })
-          );
-        });
-      }, 1000);
-
-      window.idpc = {
-        shippingFormBinding: shippingFormBinding,
-        billingFormBindings: billingFormBindings,
+        jQuery: jQuery,
       }
     });
   });
-})();
+});
 </script>

--- a/view/frontend/templates/checkout_index_index.phtml
+++ b/view/frontend/templates/checkout_index_index.phtml
@@ -1,59 +1,61 @@
 <?php
 $helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data'); ?>
 <script type="text/javascript">
-var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
-var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
-var addressAutocomplete = <?php echo $helper->getConfig(
-    'addressAutocomplete'
-); ?>;
-var populateOrganisation = <?php echo $helper->getConfig(
-    'populateOrganisation'
-); ?>;
-var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
-var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
-var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+(function () {
+  var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
+  var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
+  var addressAutocomplete = <?php echo $helper->getConfig(
+      'addressAutocomplete'
+  ); ?>;
+  var populateOrganisation = <?php echo $helper->getConfig(
+      'populateOrganisation'
+  ); ?>;
+  var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
+  var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
+  var enabled = <?php echo $helper->getConfig('enabled'); ?>;
 
-requirejs(['jquery'], function(jQuery){
-  jQuery(function() {
-    // Exit early if disabled
-    if (enabled === false) return;
+  requirejs(['jquery'], function(jQuery){
+    jQuery(function() {
+      // Exit early if disabled
+      if (enabled === false) return;
 
-    var shippingFormBinding  = new IdpcBinding({
-      container: '#checkout-step-shipping',
-      api_key: api_key,
-      postcodeLookup: postcodeLookup,
-      requireCounty: requireCounty,
-      addressAutocomplete: addressAutocomplete,
-      populateOrganisation: populateOrganisation,
-      hoistCountryField: hoistCountryField,
-      jQuery: jQuery
-    });
-
-    var billingFormBindings = [];
-    var interval = setInterval(function () {
-      var $instances = jQuery(".billing-address-form");
-      if ($instances.length === 0) return;
-      clearInterval(interval);
-      $instances.each(function (_, $instance) {
-        billingFormBindings.push(
-          new IdpcBinding({
-            container: $instance,
-            api_key: api_key,
-            postcodeLookup: postcodeLookup,
-            requireCounty: requireCounty,
-            addressAutocomplete: addressAutocomplete,
-            populateOrganisation: populateOrganisation,
-            hoistCountryField: hoistCountryField,
-            jQuery: jQuery
-          })
-        );
+      var shippingFormBinding  = new IdpcBinding({
+        container: '#checkout-step-shipping',
+        api_key: api_key,
+        postcodeLookup: postcodeLookup,
+        requireCounty: requireCounty,
+        addressAutocomplete: addressAutocomplete,
+        populateOrganisation: populateOrganisation,
+        hoistCountryField: hoistCountryField,
+        jQuery: jQuery
       });
-    }, 1000);
 
-    window.idpc = {
-      shippingFormBinding: shippingFormBinding,
-      billingFormBindings: billingFormBindings,
-    }
+      var billingFormBindings = [];
+      var interval = setInterval(function () {
+        var $instances = jQuery(".billing-address-form");
+        if ($instances.length === 0) return;
+        clearInterval(interval);
+        $instances.each(function (_, $instance) {
+          billingFormBindings.push(
+            new IdpcBinding({
+              container: $instance,
+              api_key: api_key,
+              postcodeLookup: postcodeLookup,
+              requireCounty: requireCounty,
+              addressAutocomplete: addressAutocomplete,
+              populateOrganisation: populateOrganisation,
+              hoistCountryField: hoistCountryField,
+              jQuery: jQuery
+            })
+          );
+        });
+      }, 1000);
+
+      window.idpc = {
+        shippingFormBinding: shippingFormBinding,
+        billingFormBindings: billingFormBindings,
+      }
+    });
   });
-});
+})();
 </script>

--- a/view/frontend/templates/customer_address_form.phtml
+++ b/view/frontend/templates/customer_address_form.phtml
@@ -1,45 +1,47 @@
 <?php
 $helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data'); ?>
 <script type="text/javascript">
-var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
-var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
-var addressAutocomplete = <?php echo $helper->getConfig(
-    'addressAutocomplete'
-); ?>;
-var populateOrganisation = <?php echo $helper->getConfig(
-    'populateOrganisation'
-); ?>;
-var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
-var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
-var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+(function () {
+  var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
+  var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
+  var addressAutocomplete = <?php echo $helper->getConfig(
+      'addressAutocomplete'
+  ); ?>;
+  var populateOrganisation = <?php echo $helper->getConfig(
+      'populateOrganisation'
+  ); ?>;
+  var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
+  var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
+  var enabled = <?php echo $helper->getConfig('enabled'); ?>;
 
-if (enabled === false) return;
+  if (enabled === false) return;
 
-requirejs(['jquery'], function(jQuery){
-  jQuery(function() {
-    // Exit early if disabled
-    if (enabled === false) return;
+  requirejs(['jquery'], function(jQuery){
+    jQuery(function() {
+      // Exit early if disabled
+      if (enabled === false) return;
 
-    window.idpc = {
-      formAddressEdit: new IdpcBinding({
-        container: '#form-validate',
-        api_key: api_key,
-        postcodeLookup: postcodeLookup,
-        requireCounty: requireCounty,
-        addressAutocomplete: addressAutocomplete,
-        populateOrganisation: populateOrganisation,
-        hoistCountryField: hoistCountryField,
-        jQuery: jQuery,
-        lineOneIdentifier: "#street_1",
-        lineTwoIdentifier: "#street_2",
-        lineThreeIdentifier: "#street_3",
-        organisationIdentifier: "#company",
-        postTownIdentifier: "#city",
-        countyIdentifier: "#region",
-        countryIdentifier: "#country",
-        addressLinesIdentifier: "div.field.street"
-      })
-    }
+      window.idpc = {
+        formAddressEdit: new IdpcBinding({
+          container: '#form-validate',
+          api_key: api_key,
+          postcodeLookup: postcodeLookup,
+          requireCounty: requireCounty,
+          addressAutocomplete: addressAutocomplete,
+          populateOrganisation: populateOrganisation,
+          hoistCountryField: hoistCountryField,
+          jQuery: jQuery,
+          lineOneIdentifier: "#street_1",
+          lineTwoIdentifier: "#street_2",
+          lineThreeIdentifier: "#street_3",
+          organisationIdentifier: "#company",
+          postTownIdentifier: "#city",
+          countyIdentifier: "#region",
+          countryIdentifier: "#country",
+          addressLinesIdentifier: "div.field.street"
+        })
+      }
+    });
   });
-});
+})();
 </script>

--- a/view/frontend/templates/customer_address_form.phtml
+++ b/view/frontend/templates/customer_address_form.phtml
@@ -1,47 +1,45 @@
 <?php
 $helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data'); ?>
+
 <script type="text/javascript">
-(function () {
-  var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
-  var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
-  var addressAutocomplete = <?php echo $helper->getConfig(
+requirejs(['jquery'], function(jQuery){
+  jQuery(function() {
+    var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
+    var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
+    var addressAutocomplete = <?php echo $helper->getConfig(
       'addressAutocomplete'
-  ); ?>;
-  var populateOrganisation = <?php echo $helper->getConfig(
+    ); ?>;
+    var populateOrganisation = <?php echo $helper->getConfig(
       'populateOrganisation'
-  ); ?>;
-  var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
-  var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
-  var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+    ); ?>;
+    var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
+    var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
+    var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+    var targets = "<?php echo $helper->getConfig('customer_address_target'); ?>";
 
-  if (enabled === false) return;
+    // Exit early if disabled
+    if (enabled === false) return;
 
-  requirejs(['jquery'], function(jQuery){
-    jQuery(function() {
-      // Exit early if disabled
-      if (enabled === false) return;
-
-      window.idpc = {
-        formAddressEdit: new IdpcBinding({
-          container: '#form-validate',
-          api_key: api_key,
-          postcodeLookup: postcodeLookup,
-          requireCounty: requireCounty,
-          addressAutocomplete: addressAutocomplete,
-          populateOrganisation: populateOrganisation,
-          hoistCountryField: hoistCountryField,
-          jQuery: jQuery,
-          lineOneIdentifier: "#street_1",
-          lineTwoIdentifier: "#street_2",
-          lineThreeIdentifier: "#street_3",
-          organisationIdentifier: "#company",
-          postTownIdentifier: "#city",
-          countyIdentifier: "#region",
-          countryIdentifier: "#country",
-          addressLinesIdentifier: "div.field.street"
-        })
+    window.idpc = new IdpcWatcher({
+      targets: targets,
+      options: {
+        api_key: api_key,
+        postcodeLookup: postcodeLookup,
+        requireCounty: requireCounty,
+        addressAutocomplete: addressAutocomplete,
+        populateOrganisation: populateOrganisation,
+        hoistCountryField: hoistCountryField,
+        jQuery: jQuery,
+        lineOneIdentifier: "#street_1",
+        lineTwoIdentifier: "#street_2",
+        lineThreeIdentifier: "#street_3",
+        organisationIdentifier: "#company",
+        postTownIdentifier: "#city",
+        countyIdentifier: "#region",
+        countryIdentifier: "#country",
+        addressLinesIdentifier: "div.field.street"
       }
     });
   });
-})();
+});
 </script>

--- a/view/frontend/templates/multishipping_checkout.phtml
+++ b/view/frontend/templates/multishipping_checkout.phtml
@@ -1,45 +1,47 @@
 <?php
 $helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data'); ?>
 <script type="text/javascript">
-var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
-var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
-var addressAutocomplete = <?php echo $helper->getConfig(
-    'addressAutocomplete'
-); ?>;
-var populateOrganisation = <?php echo $helper->getConfig(
-    'populateOrganisation'
-); ?>;
-var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
-var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
-var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+(function () {
+  var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
+  var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
+  var addressAutocomplete = <?php echo $helper->getConfig(
+      'addressAutocomplete'
+  ); ?>;
+  var populateOrganisation = <?php echo $helper->getConfig(
+      'populateOrganisation'
+  ); ?>;
+  var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
+  var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
+  var enabled = <?php echo $helper->getConfig('enabled'); ?>;
 
-if (enabled === false) return;
+  if (enabled === false) return;
 
-requirejs(['jquery'], function(jQuery){
-  jQuery(function() {
-    // Exit early if disabled
-    if (enabled === false) return;
+  requirejs(['jquery'], function(jQuery){
+    jQuery(function() {
+      // Exit early if disabled
+      if (enabled === false) return;
 
-    window.idpc = {
-      formAddressEdit: new IdpcBinding({
-        container: '#form-validate',
-        api_key: api_key,
-        postcodeLookup: postcodeLookup,
-        requireCounty: requireCounty,
-        addressAutocomplete: addressAutocomplete,
-        populateOrganisation: populateOrganisation,
-        hoistCountryField: hoistCountryField,
-        jQuery: jQuery,
-        lineOneIdentifier: "#street_1",
-        lineTwoIdentifier: "#street_2",
-        lineThreeIdentifier: "#street_3",
-        organisationIdentifier: "#company",
-        postTownIdentifier: "#city",
-        countyIdentifier: "#region",
-        countryIdentifier: "#country",
-        addressLinesIdentifier: "div.field.street"
-      })
-    }
+      window.idpc = {
+        formAddressEdit: new IdpcBinding({
+          container: '#form-validate',
+          api_key: api_key,
+          postcodeLookup: postcodeLookup,
+          requireCounty: requireCounty,
+          addressAutocomplete: addressAutocomplete,
+          populateOrganisation: populateOrganisation,
+          hoistCountryField: hoistCountryField,
+          jQuery: jQuery,
+          lineOneIdentifier: "#street_1",
+          lineTwoIdentifier: "#street_2",
+          lineThreeIdentifier: "#street_3",
+          organisationIdentifier: "#company",
+          postTownIdentifier: "#city",
+          countyIdentifier: "#region",
+          countryIdentifier: "#country",
+          addressLinesIdentifier: "div.field.street"
+        })
+      }
+    });
   });
-});
+})();
 </script>

--- a/view/frontend/templates/multishipping_checkout.phtml
+++ b/view/frontend/templates/multishipping_checkout.phtml
@@ -1,47 +1,45 @@
 <?php
 $helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data'); ?>
+
 <script type="text/javascript">
-(function () {
-  var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
-  var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
-  var addressAutocomplete = <?php echo $helper->getConfig(
+requirejs(['jquery'], function(jQuery){
+  jQuery(function() {
+    var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
+    var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
+    var addressAutocomplete = <?php echo $helper->getConfig(
       'addressAutocomplete'
-  ); ?>;
-  var populateOrganisation = <?php echo $helper->getConfig(
+    ); ?>;
+    var populateOrganisation = <?php echo $helper->getConfig(
       'populateOrganisation'
-  ); ?>;
-  var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
-  var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
-  var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+    ); ?>;
+    var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
+    var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
+    var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+    var targets = "<?php echo $helper->getConfig('multishipping_checkout_targets'); ?>";
 
-  if (enabled === false) return;
+    // Exit early if disabled
+    if (enabled === false) return;
 
-  requirejs(['jquery'], function(jQuery){
-    jQuery(function() {
-      // Exit early if disabled
-      if (enabled === false) return;
-
-      window.idpc = {
-        formAddressEdit: new IdpcBinding({
-          container: '#form-validate',
-          api_key: api_key,
-          postcodeLookup: postcodeLookup,
-          requireCounty: requireCounty,
-          addressAutocomplete: addressAutocomplete,
-          populateOrganisation: populateOrganisation,
-          hoistCountryField: hoistCountryField,
-          jQuery: jQuery,
-          lineOneIdentifier: "#street_1",
-          lineTwoIdentifier: "#street_2",
-          lineThreeIdentifier: "#street_3",
-          organisationIdentifier: "#company",
-          postTownIdentifier: "#city",
-          countyIdentifier: "#region",
-          countryIdentifier: "#country",
-          addressLinesIdentifier: "div.field.street"
-        })
+    window.idpc = new IdpcWatcher({
+      targets: targets,
+      options: {
+        api_key: api_key,
+        postcodeLookup: postcodeLookup,
+        requireCounty: requireCounty,
+        addressAutocomplete: addressAutocomplete,
+        populateOrganisation: populateOrganisation,
+        hoistCountryField: hoistCountryField,
+        jQuery: jQuery,
+        lineOneIdentifier: "#street_1",
+        lineTwoIdentifier: "#street_2",
+        lineThreeIdentifier: "#street_3",
+        organisationIdentifier: "#company",
+        postTownIdentifier: "#city",
+        countyIdentifier: "#region",
+        countryIdentifier: "#country",
+        addressLinesIdentifier: "div.field.street"
       }
     });
   });
-})();
+});
 </script>

--- a/view/frontend/templates/multishipping_checkout_register.phtml
+++ b/view/frontend/templates/multishipping_checkout_register.phtml
@@ -1,45 +1,45 @@
 <?php
 $helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data'); ?>
+
 <script type="text/javascript">
-(function () {
-  var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
-  var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
-  var addressAutocomplete = <?php echo $helper->getConfig(
+requirejs(['jquery'], function(jQuery){
+  jQuery(function() {
+    var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
+    var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
+    var addressAutocomplete = <?php echo $helper->getConfig(
       'addressAutocomplete'
-  ); ?>;
-  var populateOrganisation = <?php echo $helper->getConfig(
+    ); ?>;
+    var populateOrganisation = <?php echo $helper->getConfig(
       'populateOrganisation'
-  ); ?>;
-  var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
-  var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
-  var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+    ); ?>;
+    var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
+    var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
+    var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+    var targets = "<?php echo $helper->getConfig('multishipping_checkout_register_target'); ?>";
 
-  requirejs(['jquery'], function(jQuery){
-    jQuery(function() {
-      // Exit early if disabled
-      if (enabled === false) return;
+    // Exit early if disabled
+    if (enabled === false) return;
 
-      window.idpc = {
-        formAddressEdit: new IdpcBinding({
-          container: '#form-validate',
-          api_key: api_key,
-          postcodeLookup: postcodeLookup,
-          requireCounty: requireCounty,
-          addressAutocomplete: addressAutocomplete,
-          populateOrganisation: populateOrganisation,
-          hoistCountryField: hoistCountryField,
-          jQuery: jQuery,
-          lineOneIdentifier: "#street_1",
-          lineTwoIdentifier: "#street_2",
-          lineThreeIdentifier: "#street_3",
-          organisationIdentifier: "#company",
-          postTownIdentifier: "#city",
-          countyIdentifier: "#region",
-          countryIdentifier: "#country",
-          addressLinesIdentifier: "div.field.street"
-        })
+    window.idpc = new IdpcWatcher({
+      targets: targets,
+      options: {
+        api_key: api_key,
+        postcodeLookup: postcodeLookup,
+        requireCounty: requireCounty,
+        addressAutocomplete: addressAutocomplete,
+        populateOrganisation: populateOrganisation,
+        hoistCountryField: hoistCountryField,
+        jQuery: jQuery,
+        lineOneIdentifier: "#street_1",
+        lineTwoIdentifier: "#street_2",
+        lineThreeIdentifier: "#street_3",
+        organisationIdentifier: "#company",
+        postTownIdentifier: "#city",
+        countyIdentifier: "#region",
+        countryIdentifier: "#country",
+        addressLinesIdentifier: "div.field.street"
       }
     });
   });
-})();
+});
 </script>

--- a/view/frontend/templates/multishipping_checkout_register.phtml
+++ b/view/frontend/templates/multishipping_checkout_register.phtml
@@ -1,43 +1,45 @@
 <?php
 $helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data'); ?>
 <script type="text/javascript">
-var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
-var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
-var addressAutocomplete = <?php echo $helper->getConfig(
-    'addressAutocomplete'
-); ?>;
-var populateOrganisation = <?php echo $helper->getConfig(
-    'populateOrganisation'
-); ?>;
-var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
-var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
-var enabled = <?php echo $helper->getConfig('enabled'); ?>;
+(function () {
+  var api_key = "<?php echo $helper->getConfig('api_key'); ?>";
+  var postcodeLookup = <?php echo $helper->getConfig('postcodeLookup'); ?>;
+  var addressAutocomplete = <?php echo $helper->getConfig(
+      'addressAutocomplete'
+  ); ?>;
+  var populateOrganisation = <?php echo $helper->getConfig(
+      'populateOrganisation'
+  ); ?>;
+  var hoistCountryField = <?php echo $helper->getConfig('hoistCountryField'); ?>;
+  var requireCounty = <?php echo $helper->getConfig('requireCounty'); ?>;
+  var enabled = <?php echo $helper->getConfig('enabled'); ?>;
 
-requirejs(['jquery'], function(jQuery){
-  jQuery(function() {
-    // Exit early if disabled
-    if (enabled === false) return;
+  requirejs(['jquery'], function(jQuery){
+    jQuery(function() {
+      // Exit early if disabled
+      if (enabled === false) return;
 
-    window.idpc = {
-      formAddressEdit: new IdpcBinding({
-        container: '#form-validate',
-        api_key: api_key,
-        postcodeLookup: postcodeLookup,
-        requireCounty: requireCounty,
-        addressAutocomplete: addressAutocomplete,
-        populateOrganisation: populateOrganisation,
-        hoistCountryField: hoistCountryField,
-        jQuery: jQuery,
-        lineOneIdentifier: "#street_1",
-        lineTwoIdentifier: "#street_2",
-        lineThreeIdentifier: "#street_3",
-        organisationIdentifier: "#company",
-        postTownIdentifier: "#city",
-        countyIdentifier: "#region",
-        countryIdentifier: "#country",
-        addressLinesIdentifier: "div.field.street"
-      })
-    }
+      window.idpc = {
+        formAddressEdit: new IdpcBinding({
+          container: '#form-validate',
+          api_key: api_key,
+          postcodeLookup: postcodeLookup,
+          requireCounty: requireCounty,
+          addressAutocomplete: addressAutocomplete,
+          populateOrganisation: populateOrganisation,
+          hoistCountryField: hoistCountryField,
+          jQuery: jQuery,
+          lineOneIdentifier: "#street_1",
+          lineTwoIdentifier: "#street_2",
+          lineThreeIdentifier: "#street_3",
+          organisationIdentifier: "#company",
+          postTownIdentifier: "#city",
+          countyIdentifier: "#region",
+          countryIdentifier: "#country",
+          addressLinesIdentifier: "div.field.street"
+        })
+      }
+    });
   });
-});
+})();
 </script>


### PR DESCRIPTION
Some configuratons/extensions appear to move forms from one part of the DOM to another

This PR:
- Narrows the range of contexts the integration expects to see address forms, allowing it to better handle unexpected DOM manipulations
- Allows users to configure custom address form targets from the admin dashboard