### PR TITLE
refactor: replace helper with view models in admin and store templates

### DIFF
--- a/ViewModel/AdminConfig.php
+++ b/ViewModel/AdminConfig.php
@@ -1,0 +1,23 @@
+<?php
+namespace Idealpostcodes\Ukaddresssearch\ViewModel;
+
+use Idealpostcodes\Ukaddresssearch\Helper\Data;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+
+class AdminConfig implements ArgumentInterface
+{
+    /**
+     * @var Data
+     */
+    private $helper;
+
+    public function __construct(Data $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    public function getAdminConfig($field)
+    {
+        return $this->helper->getAdminConfig($field);
+    }
+}

--- a/ViewModel/StoreConfig.php
+++ b/ViewModel/StoreConfig.php
@@ -1,0 +1,23 @@
+<?php
+namespace Idealpostcodes\Ukaddresssearch\ViewModel;
+
+use Idealpostcodes\Ukaddresssearch\Helper\Data;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+
+class StoreConfig implements ArgumentInterface
+{
+    /**
+     * @var Data
+     */
+    private $helper;
+
+    public function __construct(Data $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    public function getConfig($field)
+    {
+        return $this->helper->getConfig($field);
+    }
+}

--- a/view/adminhtml/layout/default.xml
+++ b/view/adminhtml/layout/default.xml
@@ -5,7 +5,11 @@
     </head>
     <body>
         <referenceContainer name="after.body.start">
-            <block name="iddqd-c-edit" class="Magento\Backend\Block\Page\RequireJs" template="Idealpostcodes_Ukaddresssearch::admin.phtml"/>
+            <block name="iddqd-c-edit" class="Magento\Backend\Block\Page\RequireJs" template="Idealpostcodes_Ukaddresssearch::admin.phtml">
+                <arguments>
+                    <argument name="view_model" xsi:type="object">Idealpostcodes\Ukaddresssearch\ViewModel\AdminConfig</argument>
+                </arguments>
+            </block>
         </referenceContainer>
     </body>
 </page>

--- a/view/adminhtml/templates/admin.phtml
+++ b/view/adminhtml/templates/admin.phtml
@@ -1,15 +1,16 @@
-<?php /** @var Magento\Framework\View\TemplateEngine\Php $this */
-$helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data');
+<?php /** @var Magento\Framework\View\Element\Template $block */
+/** @var \Idealpostcodes\Ukaddresssearch\ViewModel\AdminConfig $viewModel */
+$viewModel = $block->getData('view_model');
 ?>
 <?php if(!isset($secureRenderer)) { ?>
     <script type="text/javascript">
         document.addEventListener('DOMContentLoaded', function() {
-        var apiKey = "<?= $block->escapeJsQuote($helper->getAdminConfig('api_key')) ?>";
-        var autocomplete = <?= $block->escapeJs($helper->getAdminConfig('addressAutocomplete')) ?>;
-        var removeOrganisation = <?= $block->escapeJs($helper->getAdminConfig('removeOrganisation')) ?>;
-        var populateCounty = <?= $block->escapeJs($helper->getAdminConfig('requireCounty')) ?>;
-        var enabled = <?= $block->escapeJs($helper->getAdminConfig('enabled')) ?>;
-        var customFields = <?= $block->escapeJs(trim(preg_replace("/\r|\n/", "", $helper->getAdminConfig('customFields')))) ?>;
+        var apiKey = "<?= $block->escapeJsQuote($viewModel->getAdminConfig('api_key')) ?>";
+        var autocomplete = <?= $block->escapeJs($viewModel->getAdminConfig('addressAutocomplete')) ?>;
+        var removeOrganisation = <?= $block->escapeJs($viewModel->getAdminConfig('removeOrganisation')) ?>;
+        var populateCounty = <?= $block->escapeJs($viewModel->getAdminConfig('requireCounty')) ?>;
+        var enabled = <?= $block->escapeJs($viewModel->getAdminConfig('enabled')) ?>;
+        var customFields = <?= $block->escapeJs(trim(preg_replace("/\r|\n/", "", $viewModel->getAdminConfig('customFields')))) ?>;
         // Exit early if disabled
         if (enabled === false) return;
         window.idpcConfig = {
@@ -27,12 +28,12 @@ $helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data');
 <?php } else {
     echo $secureRenderer->renderTag('script', [], '
         document.addEventListener("DOMContentLoaded", function() {
-          var apiKey = "' . $block->escapeJsQuote($helper->getAdminConfig('api_key')) . '";
-          var autocomplete = ' . $block->escapeJs($helper->getAdminConfig('addressAutocomplete')) . ';
-          var removeOrganisation = ' . $block->escapeJs($helper->getAdminConfig('removeOrganisation')) . ';
-          var populateCounty = ' . $block->escapeJs($helper->getAdminConfig('requireCounty')) . ';
-          var enabled = ' . $block->escapeJs($helper->getAdminConfig('enabled')) . ';
-          var customFields = ' . $block->escapeJs(trim(preg_replace("/\r|\n/", "", $helper->getAdminConfig('customFields')))) . ';
+          var apiKey = "' . $block->escapeJsQuote($viewModel->getAdminConfig('api_key')) . '";
+          var autocomplete = ' . $block->escapeJs($viewModel->getAdminConfig('addressAutocomplete')) . ';
+          var removeOrganisation = ' . $block->escapeJs($viewModel->getAdminConfig('removeOrganisation')) . ';
+          var populateCounty = ' . $block->escapeJs($viewModel->getAdminConfig('requireCounty')) . ';
+          var enabled = ' . $block->escapeJs($viewModel->getAdminConfig('enabled')) . ';
+          var customFields = ' . $block->escapeJs(trim(preg_replace("/\r|\n/", "", $viewModel->getAdminConfig('customFields')))) . ';
           // Exit early if disabled
           if (enabled === false) return;
           window.idpcConfig = {

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -5,7 +5,11 @@
     </head>
     <body>
         <referenceBlock name="head.additional">
-            <block class="Magento\Framework\View\Element\Template" name="idealpostcodes.ukaddresssearch.store" template="Idealpostcodes_Ukaddresssearch::store.phtml" />
+            <block class="Magento\Framework\View\Element\Template" name="idealpostcodes.ukaddresssearch.store" template="Idealpostcodes_Ukaddresssearch::store.phtml">
+                <arguments>
+                    <argument name="view_model" xsi:type="object">Idealpostcodes\Ukaddresssearch\ViewModel\StoreConfig</argument>
+                </arguments>
+            </block>
         </referenceBlock>
     </body>
 </page>

--- a/view/frontend/templates/store.phtml
+++ b/view/frontend/templates/store.phtml
@@ -1,19 +1,21 @@
 <?php
-$helper = $this->helper('Idealpostcodes\Ukaddresssearch\Helper\Data');
+/** @var \Magento\Framework\View\Element\Template $block */
+/** @var \Idealpostcodes\Ukaddresssearch\ViewModel\StoreConfig $viewModel */
+$viewModel = $block->getData('view_model');
 ?>
 <?php if(!isset($secureRenderer)) { ?>
 <script type="text/javascript" name="Ideal_Postcodes">
 document.addEventListener('DOMContentLoaded', function() {
-  var apiKey = "<?= $block->escapeJsQuote($helper->getConfig('api_key')) ?>";
-  var postcodeLookup = <?= $block->escapeJs($helper->getConfig('postcodeLookup')) ?>;
-  var autocomplete = <?= $block->escapeJs($helper->getConfig('addressAutocomplete')) ?>;
-  var removeOrganisation = <?= $block->escapeJs($helper->getConfig('removeOrganisation')) ?>;
-  var hoistCountry = <?= $block->escapeJs($helper->getConfig('hoistCountryField')) ?>;
-  var populateCounty = <?= $block->escapeJs($helper->getConfig('requireCounty')) ?>;
-  var autocompleteOverride = <?= /* @noEscape */ $helper->getConfig('autocompleteOverride') ?>;
-  var postcodeLookupOverride = <?= /* @noEscape */ $helper->getConfig('postcodeLookupOverride') ?>;
-  var enabled = <?= $block->escapeJs($helper->getConfig('enabled')) ?>;
-  var customFields = <?= /* @noEscape */ trim(preg_replace('/\r|\n/', '', $helper->getConfig('customFields'))) ?>;
+  var apiKey = "<?= $block->escapeJsQuote($viewModel->getConfig('api_key')) ?>";
+  var postcodeLookup = <?= $block->escapeJs($viewModel->getConfig('postcodeLookup')) ?>;
+  var autocomplete = <?= $block->escapeJs($viewModel->getConfig('addressAutocomplete')) ?>;
+  var removeOrganisation = <?= $block->escapeJs($viewModel->getConfig('removeOrganisation')) ?>;
+  var hoistCountry = <?= $block->escapeJs($viewModel->getConfig('hoistCountryField')) ?>;
+  var populateCounty = <?= $block->escapeJs($viewModel->getConfig('requireCounty')) ?>;
+  var autocompleteOverride = <?= /* @noEscape */ $viewModel->getConfig('autocompleteOverride') ?>;
+  var postcodeLookupOverride = <?= /* @noEscape */ $viewModel->getConfig('postcodeLookupOverride') ?>;
+  var enabled = <?= $block->escapeJs($viewModel->getConfig('enabled')) ?>;
+  var customFields = <?= /* @noEscape */ trim(preg_replace('/\r|\n/', '', $viewModel->getConfig('customFields'))) ?>;
   // Exit early if disabled
   if (enabled === false) return;
   window.idpcConfig = {
@@ -33,16 +35,16 @@ document.addEventListener('DOMContentLoaded', function() {
 <?php } else {
     echo $secureRenderer->renderTag('script', [], '
     document.addEventListener("DOMContentLoaded", function() {
-      var apiKey = "' . $block->escapeJsQuote($helper->getConfig('api_key')) . '";
-      var postcodeLookup = ' . $block->escapeJs($helper->getConfig('postcodeLookup')) . ';
-      var autocomplete = ' . $block->escapeJs($helper->getConfig('addressAutocomplete')) . ';
-      var removeOrganisation = ' . $block->escapeJs($helper->getConfig('removeOrganisation')) . ';
-      var hoistCountry = ' . $block->escapeJs($helper->getConfig('hoistCountryField')) . ';
-      var populateCounty = ' . $block->escapeJs($helper->getConfig('requireCounty')) . ';
-      var autocompleteOverride = ' . /* @noEscape */ $helper->getConfig('autocompleteOverride') . ';
-      var postcodeLookupOverride = ' . /* @noEscape */ $helper->getConfig('postcodeLookupOverride') . ';
-      var enabled = ' . $block->escapeJs($helper->getConfig('enabled')) . ';
-      var customFields = ' . /* @noEscape */ trim(preg_replace('/\r|\n/', '', $helper->getConfig('customFields'))) . ';
+      var apiKey = "' . $block->escapeJsQuote($viewModel->getConfig('api_key')) . '";
+      var postcodeLookup = ' . $block->escapeJs($viewModel->getConfig('postcodeLookup')) . ';
+      var autocomplete = ' . $block->escapeJs($viewModel->getConfig('addressAutocomplete')) . ';
+      var removeOrganisation = ' . $block->escapeJs($viewModel->getConfig('removeOrganisation')) . ';
+      var hoistCountry = ' . $block->escapeJs($viewModel->getConfig('hoistCountryField')) . ';
+      var populateCounty = ' . $block->escapeJs($viewModel->getConfig('requireCounty')) . ';
+      var autocompleteOverride = ' . /* @noEscape */ $viewModel->getConfig('autocompleteOverride') . ';
+      var postcodeLookupOverride = ' . /* @noEscape */ $viewModel->getConfig('postcodeLookupOverride') . ';
+      var enabled = ' . $block->escapeJs($viewModel->getConfig('enabled')) . ';
+      var customFields = ' . /* @noEscape */ trim(preg_replace('/\r|\n/', '', $viewModel->getConfig('customFields'))) . ';
       // Exit early if disabled
       if (enabled === false) return;
       window.idpcConfig = {


### PR DESCRIPTION
Replace direct helper calls with view model pattern in admin.phtml and store.phtml templates. Add AdminConfig and StoreConfig view models to layout XML files and update template variable references from $helper to $viewModel.