### PR TITLE
chore(ci): upgrade checkout action to v4 with full history fetch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Use Node.js
         uses: useblacksmith/setup-node@v5


### PR DESCRIPTION
Update actions/checkout from v1 to v4 with fetch-depth: 0 to enable full git history access and persist-credentials: false for security.